### PR TITLE
Adding Growth Rate to throughput monitor

### DIFF
--- a/src/Persistence/CosmosDbThroughputHelper.cs
+++ b/src/Persistence/CosmosDbThroughputHelper.cs
@@ -8,7 +8,7 @@ namespace PipServices.Azure.Persistence
     {
         public const int BufferThroughput = 100;
 
-        public static int GetRecommendedThroughput(int partitionCount, double maximumRequestUnitValue, int minimumThroughput, int maximumThroughput)
+        public static int GetRecommendedThroughput(int partitionCount, double maximumRequestUnitValue, int minimumThroughput, int maximumThroughput, double growthRate)
         {
             if (partitionCount <= 0)
             {
@@ -18,9 +18,10 @@ namespace PipServices.Azure.Persistence
             if (maximumRequestUnitValue <= minimumThroughput)
             {
                 maximumRequestUnitValue = minimumThroughput;
+                growthRate = 1.0;
             }
 
-            var result = Math.Ceiling(maximumRequestUnitValue / 100) * 100;
+            var result = Math.Ceiling(maximumRequestUnitValue / 100 * growthRate) * 100;
 
             result = result * partitionCount + BufferThroughput;
 

--- a/test/Persistence/ThroughputHelperTest.cs
+++ b/test/Persistence/ThroughputHelperTest.cs
@@ -14,7 +14,7 @@ namespace PipServices.Azure.Persistence
         {
             // act
             var result = CosmosDbThroughputHelper.GetRecommendedThroughput(partitionCount, maximumRequestUnitValue,
-                AbstractCosmosDbPersistenceThroughputMonitor.DefaultMinimumThroughput, AbstractCosmosDbPersistenceThroughputMonitor.DefaultMaximumThroughput);
+                AbstractCosmosDbPersistenceThroughputMonitor.DefaultMinimumThroughput, AbstractCosmosDbPersistenceThroughputMonitor.DefaultMaximumThroughput, AbstractCosmosDbPersistenceThroughputMonitor.DefaultGrowthRate);
 
             // assert
             Assert.Equal(expectedThroughput, result);
@@ -27,7 +27,7 @@ namespace PipServices.Azure.Persistence
         {
             // act
             var result = CosmosDbThroughputHelper.GetRecommendedThroughput(partitionCount, maximumRequestUnitValue,
-                AbstractCosmosDbPersistenceThroughputMonitor.DefaultMinimumThroughput, AbstractCosmosDbPersistenceThroughputMonitor.DefaultMaximumThroughput);
+                AbstractCosmosDbPersistenceThroughputMonitor.DefaultMinimumThroughput, AbstractCosmosDbPersistenceThroughputMonitor.DefaultMaximumThroughput, AbstractCosmosDbPersistenceThroughputMonitor.DefaultGrowthRate);
 
             // assert
             Assert.Equal(expectedThroughput, result);
@@ -53,7 +53,24 @@ namespace PipServices.Azure.Persistence
         {
             // act
             var result = CosmosDbThroughputHelper.GetRecommendedThroughput(partitionCount, maximumRequestUnitValue,
-                AbstractCosmosDbPersistenceThroughputMonitor.DefaultMinimumThroughput, AbstractCosmosDbPersistenceThroughputMonitor.DefaultMaximumThroughput);
+                AbstractCosmosDbPersistenceThroughputMonitor.DefaultMinimumThroughput, AbstractCosmosDbPersistenceThroughputMonitor.DefaultMaximumThroughput, AbstractCosmosDbPersistenceThroughputMonitor.DefaultGrowthRate);
+
+            // assert
+            Assert.Equal(expectedThroughput, result);
+        }
+
+        [Theory]
+        [InlineData(1, 5000, 1.5, 7600)]        // (1 * 5000) = 5000 * 1.5 = 2500 + 100 = 7600
+        [InlineData(1, 100, 1.5, AbstractCosmosDbPersistenceThroughputMonitor.DefaultMinimumThroughput + CosmosDbThroughputHelper.BufferThroughput)]
+        [InlineData(2, 5000, 1.5, 15100)]       // (2 * 5000) = 10000 * 1.5 = 5000 + 100 = 15100
+        [InlineData(5, 5000, 1.5, 37600)]       // (5 * 5000) = 25000 * 1.5 = 37500 + 100 = 37600
+        [InlineData(10, 5000, 1.5, 75100)]
+        [InlineData(10, 10000, 1.5, AbstractCosmosDbPersistenceThroughputMonitor.DefaultMaximumThroughput)]
+        public void It_Should_Recommend_Correct_Throughput_Value_For_Growth_Rate(int partitionCount, double maximumRequestUnitValue, double growthRate, int expectedThroughput)
+        {
+            // act
+            var result = CosmosDbThroughputHelper.GetRecommendedThroughput(partitionCount, maximumRequestUnitValue,
+                AbstractCosmosDbPersistenceThroughputMonitor.DefaultMinimumThroughput, AbstractCosmosDbPersistenceThroughputMonitor.DefaultMaximumThroughput, growthRate);
 
             // assert
             Assert.Equal(expectedThroughput, result);


### PR DESCRIPTION
Some objects are too large to make it through Cosmos without scaling up throughput rapidly (inventory_supplies for example). To prevent from having to set the minimum throughput very high and costing too much money while idle, this setting allows the collection to scale up faster and keep the minimum throughput low.